### PR TITLE
Fix license entry to be SPDX conform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # DEV
 
+* fix license entry to be SPDX conform
 * depend on version >= 4.x and < 5 of nodejs
 * replaced grunt-autoprefixer by grunt-postcss and autoprefixer
 * requirejs uglify disabled

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-nikita",
   "description": "The official yeoman generator for nikita.kit",
-  "license": "CC0",
+  "license": "CC0-1.0",
   "main": "app/index.js",
   "repository": "nikita-kit/generator-nikita",
   "author": {


### PR DESCRIPTION
npm says:
``` console
npm WARN package.json generator-nikita@ license should be a valid SPDX license expression
``` 