### PR TITLE
Added 'sass-globbing' task to glob new files while watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dev
+
+- regenerate sass globbing on added/removed glob imported scss files
+
 # 4.0.1 (2017/11/29)
 
 * fixed bug in sample component where the folder was added twice (uppercase and lowercase)

--- a/app/templates/grunt/config/watch.js.ejs
+++ b/app/templates/grunt/config/watch.js.ejs
@@ -5,7 +5,7 @@ module.exports = {
     },
     scss: {
         files: ['<%%= paths.src %>/sass/**/*.scss', '<%%= paths.src %>/components/**/*.scss'],
-        tasks: ['sass:dev', 'postcss:dev']
+        tasks: ['sass-globbing', 'sass:dev', 'postcss:dev']
     },<% if (config.get('features').indexOf('svgBackgrounds') != -1) { %>
     svg_bgs: {
         files: ['<%%= paths.src %>/img/bgs/*.svg'],


### PR DESCRIPTION
New scss files were not added to the generated styles.css unless grunt was restarted.