### PR TITLE
added grunt task to check licenses used in the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * fixed generator version compare bug
 * added nikita version to npm generator script target
 * internal: added method to copy complete template directory to generator
+* added grunt task to check licenses used in the project
 
 # 5.2.0 (2019/05/08)
 

--- a/app/index.js
+++ b/app/index.js
@@ -329,10 +329,12 @@ module.exports = class extends Generator {
 
         // grunt Files
         this._copyTemplate('grunt/aliases.js.ejs', 'grunt/aliases.js');
+        this._copyTemplate('grunt/tasks/check-licenses.js.ejs', 'grunt/tasks/check-licenses.js');
         this._copyTemplate('grunt/tasks/sass-globbing.js.ejs', 'grunt/tasks/sass-globbing.js');
         this._copyTemplate('grunt/tasks/jest.js.ejs', 'grunt/tasks/jest.js');
 
         this._copyTemplate('grunt/config/browserSync.js.ejs', 'grunt/config/browserSync.js');
+        this._copyTemplate('grunt/config/check-licenses.js.ejs', 'grunt/config/check-licenses.js');
         this._copyTemplate('grunt/config/clean.js.ejs', 'grunt/config/clean.js');
         this._copyTemplate('grunt/config/concurrent.js.ejs', 'grunt/config/concurrent.js');
         this._copyTemplate('grunt/config/eslint.js.ejs', 'grunt/config/eslint.js');

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -72,6 +72,7 @@
         "import-glob": "1.5.0",
         "jest-cli": "24.9.0",
         "jit-grunt": "0.10.0",
+        "license-checker": "25.0.1",
         "load-grunt-config": "3.0.1",
         "node-sass": "4.13.0",
         "postcss-csso": "4.0.0",

--- a/app/templates/grunt/config/check-licenses.js.ejs
+++ b/app/templates/grunt/config/check-licenses.js.ejs
@@ -1,0 +1,21 @@
+module.exports = {
+    all: {
+        options: {
+            allowedLicenses: [
+                "MIT",
+                "ISC",
+                "Apache-2.0",
+                "BSD",
+                "BSD-2-Clause",
+                "BSD-3-Clause",
+                "CC0-1.0",
+                "WTFPL",
+                "LGPL",
+                "CC-BY-3.0",
+                "CC-BY-4.0",
+                "MPL-2.0",
+                "Public Domain",
+            ],
+        },
+    },
+};

--- a/app/templates/grunt/tasks/check-licenses.js.ejs
+++ b/app/templates/grunt/tasks/check-licenses.js.ejs
@@ -1,0 +1,41 @@
+const licenseChecker = require('license-checker');
+
+module.exports = function (grunt) {
+    grunt.registerMultiTask('check-licenses', 'check the used packages for invalid licenses', function () {
+        grunt.log.write('\n>> '.green);
+        grunt.log.writeln('starting license check');
+
+        const done = this.async();
+        const taskOptions = this.options();
+
+        const excludedLicenses = taskOptions.allowedLicenses.join(',');
+
+        const options = {
+            start: process.cwd(),
+            json: true,
+            exclude: excludedLicenses
+        };
+
+        licenseChecker.init(options, (err, packages) => {
+            if (err) {
+                grunt.log.writeln('An unexpected error occured while performing the license check '.red);
+                done(false);
+                return;
+            }
+            const packageNames = Object.keys(packages);
+            if (packageNames.length === 0) {
+                grunt.log.writeln('all dependency licenses are allowed in the whitelist');
+                done(true);
+                return;
+            }
+            packageNames.forEach(key => {
+                grunt.log.write('Package: ');
+                grunt.log.write(key.red);
+                grunt.log.write(', is not allowed because of License: ');
+                grunt.log.writeln(packages[key].licenses.yellow);
+            });
+            grunt.log.writeln();
+            done(false);
+        });
+    });
+};

--- a/app/templates/grunt/tasks/check-licenses.js.ejs
+++ b/app/templates/grunt/tasks/check-licenses.js.ejs
@@ -13,7 +13,8 @@ module.exports = function (grunt) {
         const options = {
             start: process.cwd(),
             json: true,
-            exclude: excludedLicenses
+            exclude: excludedLicenses,
+            production: true,
         };
 
         licenseChecker.init(options, (err, packages) => {


### PR DESCRIPTION
added a new grunt task that uses the npm package license-checker to recursively check licenses of dependencies. This should be really helpful in frequently verifying that no licenses are violated. The process emits the right exit code, so it could also be used in CI.